### PR TITLE
feat(github-settings): set main as default branch

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -5,8 +5,9 @@ repository:
   allow_squash_merge: false
   allow_merge_commit: true
   allow_rebase_merge: true
+  default_branch: main
 branches:
-  - name: master
+  - name: main
     protection:
       required_pull_request_reviews: null
       required_status_checks: null


### PR DESCRIPTION
thought i'd at least give us a place to start here. if i understand correctly, using this on a new repo would break semantic-release as of right now unless we re-wrote the default branches manually per [this issue](https://github.com/semantic-release/semantic-release/issues/1581).